### PR TITLE
make src/server/server.js the server bundle entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV MONGO_URL=mongodb://mongo:27017/crater \
     ROOT_URL=http://localhost:80 \
     PORT=80
 
-CMD ["node", "server/index.js"]
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ The Express server is configured to perform React server-side rendering and adde
 The client-side code is bundled using Webpack and [meteor-imports-webpack-plugin](https://github.com/luisherranz/meteor-imports-webpack-plugin), and comes with all the usual
 goodies in this skeleton: `react-hot-loader`, `redux`, `react-router`, `react-router-redux`.
 
+In production the server-side code is also bundled using Webpack with `extract-text-webpack-plugin` so that it can
+render React modules that require `.css` files.
+
+## Where to put things
+
+All of your server code should go in `src/server/server.js` or a file required by it.  You shouldn't require any app
+code in `src/server/index.js`, because the production build makes a server-side Webpack bundle with
+`src/server/server.js` as the entry point, so anything you require in `src/server/index.js` would be duplicated in the
+Webpack bundle.
+
 ## Windows not supported yet
 
 Windows is not yet supported because the npm scripts are all written in bash.  It might work with bash from [Cygwin](https://www.cygwin.com/) or [Windows Subsystem for Linux](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=install%20windows%20subsystem%20for%20linux)

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "scripts": {
     "start": "NODE_ENV=development USE_DOTENV=1 node src/server/devServer.babel.js & NODE_ENV=development USE_DOTENV=1 node src/server/index.js",
     "build": "rimraf build && npm run build:server && npm run build:client",
-    "build:server": "NODE_ENV=production webpack --config ./webpack/server.babel.js && babel src --out-dir build && cd meteor && meteor build ../build/meteor --directory",
+    "build:server": "NODE_ENV=production webpack --config ./webpack/server.babel.js && babel src/server/index.js -o build/index.js && cd meteor && meteor build ../build/meteor --directory",
     "build:client": "NODE_ENV=production webpack --config ./webpack/prod.babel.js",
-    "prod": "NODE_ENV=production USE_DOTENV=1 node build/server/index.js",
+    "prod": "NODE_ENV=production USE_DOTENV=1 node build/index.js",
     "test": "node run-integration-test.babel.js",
     "test:dev": "node run-integration-test.babel.js --mochaOpts.grep dev",
     "test:prod": "node run-integration-test.babel.js --mochaOpts.grep prod",
@@ -82,7 +82,8 @@
     "webdriverio": "^4.2.11",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.6.1",
-    "webpack-hot-middleware": "^2.12.2"
+    "webpack-hot-middleware": "^2.12.2",
+    "webpack-node-externals": "^1.3.3"
   },
   "repository": {
     "type": "git",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,6 +2,8 @@ global.__CLIENT__ = false
 
 if (process.env.USE_DOTENV) require('dotenv').config()
 
+global.__PRODUCTION__ = process.env.NODE_ENV === 'production'
+
 if (process.env.NODE_ENV === 'production' || require('piping')({
   hook: false,
   ignore: /(\/\.|~$|\.json$)/i
@@ -10,7 +12,7 @@ if (process.env.NODE_ENV === 'production' || require('piping')({
 
   // I'm not super happy about this, but Meteor's boot.js seems to require being run from the directory it's in
   const serverDir = process.env.NODE_ENV === 'production'
-    ? path.resolve(__dirname, '../meteor/bundle/programs/server')
+    ? path.resolve(__dirname, 'meteor/bundle/programs/server')
     : path.resolve(__dirname, '../../meteor/.meteor/local/build/programs/server')
   process.chdir(serverDir)
   var argv = process.argv
@@ -25,6 +27,10 @@ if (process.env.NODE_ENV === 'production' || require('piping')({
   }
 
   Package.meteor.Meteor.startup(function () {
-    require('./server')
+    if (process.env.NODE_ENV === 'production') {
+      require('./prerender')
+    } else {
+      require('./server')
+    }
   })
 }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -16,7 +16,7 @@ app.use((req, res, next) => {
 })
 
 if (process.env.NODE_ENV === 'production') {
-  app.use('/static', express.static(path.resolve(__dirname, '../static')))
+  app.use('/static', express.static(path.resolve(__dirname, 'static')))
 }
 
 // server-side rendering

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -3,6 +3,7 @@ import webpack from 'webpack'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import HappyPack from 'happypack'
 import ProgressBarPlugin from 'progress-bar-webpack-plugin'
+import nodeExternals from 'webpack-node-externals'
 
 const root = path.resolve(__dirname, '..')
 const srcDir = path.resolve(root, 'src')
@@ -11,9 +12,13 @@ const globalCSS = path.join(srcDir, 'styles', 'global')
 const config = {
   context: root,
   entry: {
-    prerender: './src/universal/routes/index.js'
+    prerender: './src/server/server'
   },
   target: 'node',
+  node: {
+    __dirname: false,
+    __filename: false,
+  },
   output: {
     path: path.join(root, 'build'),
     chunkFilename: '[name]_[chunkhash].js',
@@ -23,7 +28,7 @@ const config = {
   },
   // ignore anything that throws warnings & doesn't affect the view
   externals: [
-    'es6-promisify',
+    nodeExternals(),
     (context, request, callback) => {
       const match = /^meteor\/(.*)$/.exec(request)
       if (match) {
@@ -34,7 +39,7 @@ const config = {
   ],
   plugins: [
     new webpack.NoErrorsPlugin(),
-    new ExtractTextPlugin('[name].css'),
+    new ExtractTextPlugin('/static/[name].css'),
     new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}}),
     new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
     new webpack.DefinePlugin({


### PR DESCRIPTION
This solves issues with modules in `universal` getting duplicated and run twice, which could crash the server if e.g. a `Mongo.Collection` gets created with the same name twice.  I also fixed the path for `prerender.css`.