### PR TITLE
fix isNewerThan logic and add tests

### DIFF
--- a/scripts/build-client.js
+++ b/scripts/build-client.js
@@ -8,10 +8,11 @@ import spawnAsync from '../util/spawnAsync'
 process.on('SIGINT', () => process.exit(1))
 
 const root = path.resolve(__dirname, '..')
+const assets = path.join(root, 'build', 'assets.json')
 
 asyncScript(async () => {
-  if (await isNewerThan(path.join(root, 'src'), path.join(root, 'build', 'static')) ||
-      await isNewerThan(path.join(root, 'src'), path.join(root, 'build', 'assets.json'))) {
+  if (await isNewerThan(path.join(root, 'webpack', 'webpack.config.prod.js'), assets) ||
+      await isNewerThan(path.join(root, 'src'), assets)) {
     console.log('building client bundle...')
     await spawnAsync('webpack', ['--config', path.join(root, 'webpack', 'prod.babel.js')], {stdio: 'inherit'})
   } else {

--- a/scripts/build-server.js
+++ b/scripts/build-server.js
@@ -9,10 +9,12 @@ process.on('SIGINT', () => process.exit(1))
 
 const root = path.resolve(__dirname, '..')
 const build = path.join(root, 'build')
+const prerender = path.join(build, 'prerender.js')
 
 asyncScript(async () => {
   await spawnAsync('babel', [path.join(root, 'src', 'index.js'), '-o', path.join(build, 'index.js')], {stdio: 'inherit'})
-  if (await isNewerThan(path.join(root, 'src'), path.join(root, 'build', 'prerender.js'))) {
+  if (await isNewerThan(path.join(root, 'webpack', 'webpack.config.server.js'), prerender) ||
+      await isNewerThan(path.join(root, 'src'), prerender)) {
     console.log('building server bundle...')
     await spawnAsync('webpack', ['--config', path.join(root, 'webpack', 'server.babel.js')], {stdio: 'inherit'})
   } else {

--- a/test/integration/integrationTests.js
+++ b/test/integration/integrationTests.js
@@ -57,7 +57,7 @@ function unlinkIfExists(path, callback) {
 describe('build scripts', function () {
   describe('build:meteor', async function () {
     it('only rebuilds when necessary', async function () {
-      this.timeout(120000)
+      this.timeout(480000)
 
       await promisify(rimraf)(path.join(build, 'meteor'))
       expect(/building meteor packages/i.test((await execAsync('npm run build:meteor')).stdout)).to.be.true
@@ -77,7 +77,7 @@ describe('build scripts', function () {
   })
   describe('build:client', function () {
     it('only rebuilds when necessary', async function () {
-      this.timeout(120000)
+      this.timeout(480000)
 
       await spawnAsync('npm', ['run', 'build:meteor'], {stdio: 'inherit'})
 
@@ -107,7 +107,7 @@ describe('build scripts', function () {
   })
   describe('build:server', function () {
     it('only rebuilds when necessary', async function () {
-      this.timeout(120000)
+      this.timeout(480000)
 
       await spawnAsync('npm', ['run', 'build:meteor'], {stdio: 'inherit'})
 

--- a/test/integration/integrationTests.js
+++ b/test/integration/integrationTests.js
@@ -7,8 +7,14 @@ import spawnAsync from '../../util/spawnAsync'
 import execAsync from '../../util/execAsync'
 import path from 'path'
 import fs from 'fs'
+import rimraf from 'rimraf'
 import promisify from 'es6-promisify'
 import webpackConfig from '../../webpack/webpack.config.dev'
+
+const root = path.resolve(__dirname, '..', '..')
+const src = path.join(root, 'src')
+const build = path.join(root, 'build')
+const webpack = path.join(root, 'webpack')
 
 async function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -40,6 +46,96 @@ function sharedTests() {
     expect(await browser.getText('.settings-test')).to.equal('success')
   })
 }
+
+function unlinkIfExists(path, callback) {
+  return fs.unlink(path, (err, result) => {
+    if (err && /ENOENT/.test(err.message)) err = null
+    return callback(err, result)
+  })
+}
+
+describe('build scripts', function () {
+  describe('build:meteor', async function () {
+    it('only rebuilds when necessary', async function () {
+      this.timeout(120000)
+
+      await promisify(rimraf)(path.join(build, 'meteor'))
+      expect(/building meteor packages/i.test((await execAsync('npm run build:meteor')).stdout)).to.be.true
+
+      expect(/build\/meteor is up to date/i.test((await execAsync('npm run build:meteor')).stdout)).to.be.true
+
+      await delay(1000)
+      await promisify(fs.utimes)(
+        path.resolve(root, 'meteor', '.meteor', 'packages'),
+        NaN,
+        NaN,
+      )
+      expect(/building meteor packages/i.test((await execAsync('npm run build:meteor')).stdout)).to.be.true
+
+      expect(/build\/meteor is up to date/i.test((await execAsync('npm run build:meteor')).stdout)).to.be.true
+    })
+  })
+  describe('build:client', function () {
+    it('only rebuilds when necessary', async function () {
+      this.timeout(120000)
+
+      await spawnAsync('npm', ['run', 'build:meteor'], {stdio: 'inherit'})
+
+      await promisify(unlinkIfExists)(path.join(build, 'assets.json'))
+      expect(/building client bundle/.test((await execAsync('npm run build:client')).stdout)).to.be.true
+
+      expect(/client assets are up to date/.test((await execAsync('npm run build:client')).stdout)).to.be.true
+
+      await delay(1000)
+      await promisify(fs.utimes)(
+        path.resolve(webpack, 'webpack.config.prod.js'),
+        NaN,
+        NaN
+      )
+      expect(/building client bundle/.test((await execAsync('npm run build:client')).stdout)).to.be.true
+
+      await delay(1000)
+      await promisify(fs.utimes)(
+        path.resolve(src, 'client', 'index.js'),
+        NaN,
+        NaN
+      )
+      expect(/building client bundle/.test((await execAsync('npm run build:client')).stdout)).to.be.true
+
+      expect(/client assets are up to date/.test((await execAsync('npm run build:client')).stdout)).to.be.true
+    })
+  })
+  describe('build:server', function () {
+    it('only rebuilds when necessary', async function () {
+      this.timeout(120000)
+
+      await spawnAsync('npm', ['run', 'build:meteor'], {stdio: 'inherit'})
+
+      await promisify(unlinkIfExists)(path.join(build, 'prerender.js'))
+      expect(/building server bundle/.test((await execAsync('npm run build:server')).stdout)).to.be.true
+
+      expect(/server assets are up to date/.test((await execAsync('npm run build:server')).stdout)).to.be.true
+
+      await delay(1000)
+      await promisify(fs.utimes)(
+        path.resolve(webpack, 'webpack.config.server.js'),
+        NaN,
+        NaN
+      )
+      expect(/building server bundle/.test((await execAsync('npm run build:server')).stdout)).to.be.true
+
+      await delay(1000)
+      await promisify(fs.utimes)(
+        path.resolve(src, 'server', 'index.js'),
+        NaN,
+        NaN
+      )
+      expect(/building server bundle/.test((await execAsync('npm run build:server')).stdout)).to.be.true
+
+      expect(/server assets are up to date/.test((await execAsync('npm run build:server')).stdout)).to.be.true
+    })
+  })
+})
 
 describe('prod mode', function () {
   let server
@@ -104,8 +200,8 @@ describe('docker build', function () {
 describe('dev mode', function () {
   let server
 
-  const appFile = path.resolve(__dirname, '../../src/universal/components/App.js')
-  const serverFile = path.resolve(__dirname, '../../src/server/index.js')
+  const appFile = path.join(src, 'universal', 'components', 'App.js')
+  const serverFile = path.join(src, 'server', 'index.js')
   let appCode, serverCode
 
   before(async function () {

--- a/util/getMaxMtime.js
+++ b/util/getMaxMtime.js
@@ -1,0 +1,12 @@
+import fs from 'fs'
+import glob from 'glob'
+import path from 'path'
+import promisify from 'es6-promisify'
+
+async function getMaxMtime(p) {
+  const files = await promisify(glob)(path.join(p, '**'), {dot: true})
+  const mtimes = await Promise.all(files.map(async file => (await promisify(fs.stat)(file)).mtime))
+  return Math.max((await promisify(fs.stat)(p)).mtime, ...mtimes.map(date => date.getTime()))
+}
+
+export default getMaxMtime

--- a/util/isNewerThan.js
+++ b/util/isNewerThan.js
@@ -1,12 +1,14 @@
-import fs from 'fs'
+import getMaxMtime from './getMaxMtime'
 
+/*
+ * This is basically an implementation of the bash `-nt` operator.
+ * Resolves to `true` iff `path1` is newer than that at `path2` (or `path2` doesn't exist).
+ * If a directory path is given, takes the maximum `mtime` of all files/directories within it.
+ */
 async function isNewerThan(path1, path2) {
-  return new Promise((resolve, reject) => {
-    fs.stat(path1, (err, stats1) => {
-      if (err) return reject(err)
-      fs.stat(path2, (err, stats2) => {
-        return resolve(err ? true : stats1.mtime > stats2.mtime)
-      })
+  return new Promise(async (resolve, reject) => {
+    getMaxMtime(path1).catch(reject).then(mtime1 => {
+      getMaxMtime(path2).catch(() => resolve(true)).then(mtime2 => resolve(mtime1 > mtime2))
     })
   })
 }

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -14,6 +14,7 @@ const clientInclude = [srcDir]
 const vendor = [
   'react',
   'react-dom',
+  'meteor-imports',
 ]
 
 const config = {


### PR DESCRIPTION
This fixes the logic used to determine rather to rebuild meteor packages, client assets, and server assets.