### PR TITLE
Allow resolving imports from 'src'

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015", "stage-1", "react", "flow"],
   "plugins": [
     "transform-runtime",
-    "meteor-imports"
+    "meteor-imports",
+    ["resolver", {"resolveDirs": ["src"]}]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-meteor-imports": "^1.0.3",
+    "babel-plugin-resolver": "^1.1.0",
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2015-node5": "^1.2.0",


### PR DESCRIPTION
I'm not sure if you want to include this in your project or just leave it as an exercise for the user. Using the webpack resolve property doesn't work because that's client code only.

This PR allows you to import files relative to `src`.

```
import MyComponent from 'myModule/components/MyComponent';
```