### PR TITLE
Fix json loading in node modules, prevent double loading meteor-config

### DIFF
--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -56,7 +56,7 @@ const config = {
   postcss: [cssModulesValues],
   module: {
     loaders: [
-      { test: /\.json$/, loader: 'json-loader', include: [...clientInclude, 'node_modules'] },
+      { test: /\.json$/, loader: 'json-loader', include: [...clientInclude, path.join(root, 'node_modules')], exclude: [/meteor-config/] },
       { test: /\.txt$/, loader: 'raw-loader' },
       { test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/, loader: 'url-loader?limit=10000' },
       { test: /\.(eot|ttf|wav|mp3)$/, loader: 'file-loader' },

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -70,7 +70,7 @@ const config = {
   postcss: [cssModulesValues],
   module: {
     loaders: [
-      { test: /\.json$/, loader: 'json-loader', include: [...clientInclude, 'node_modules'] },
+      { test: /\.json$/, loader: 'json-loader',  include: [...clientInclude, path.join(root, 'node_modules')], exclude: [/meteor-config/] },
       { test: /\.txt$/, loader: 'raw-loader' },
       { test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/, loader: 'url-loader?limit=10000' },
       { test: /\.(eot|ttf|wav|mp3)$/, loader: 'file-loader' },


### PR DESCRIPTION
The current code breaks once you start to add more packages to node_modules because json does not get parsed. Updated the test to fix that. Added an exclude for meteor-config.json because meteor-imports-webpack-plugin adds a loader specifically for that file and it will crash due to being parsed twice if not excluded.